### PR TITLE
Update remotecap.cmd with -batch option

### DIFF
--- a/remotecap.cmd
+++ b/remotecap.cmd
@@ -17,5 +17,5 @@
 @SET REMOTE_INTERFACE=eth0 
 
 @REM execute command 
-%PLINK_PATH% -ssh -pw %REMOTE_PASSWORD% %REMOTE_ACCOUNT%@%REMOTE_SERVER% "tcpdump -s0 -U -w - -i %REMOTE_INTERFACE% not port 22" | %WIRESHARK_PATH% -i - -k
+%PLINK_PATH% -batch -ssh -pw %REMOTE_PASSWORD% %REMOTE_ACCOUNT%@%REMOTE_SERVER% "tcpdump -s0 -U -w - -i %REMOTE_INTERFACE% not port 22" | %WIRESHARK_PATH% -i - -k
 	


### PR DESCRIPTION
Without -batch option, plink.exe will preface captured data with interactive text output. This causes "Error reading from pipe" error at the Wireshark side.